### PR TITLE
Add endpoints for introspecting the state of the proxy

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ func main() {
 	proxy := goproxy.NewProxyHttpServer()
 
 	server := &Server{Proxy: proxy}
-	http.Handle("/expectations", server)
+	http.Handle("/", server)
 	go http.ListenAndServe(":4322", nil)
 
 	proxy.Verbose = true

--- a/models.go
+++ b/models.go
@@ -36,7 +36,7 @@ type Expectation struct {
 	MaxMatches      int         `json:"max_matches"`
 	PassThrough     bool        `json:"pass_through"`
 
-	matches int
+	Matches int `json:"matches"`
 	mutex   sync.RWMutex
 }
 
@@ -44,7 +44,7 @@ func (e *Expectation) Match(r *http.Request) (bool, error) {
 	e.mutex.RLock()
 	defer e.mutex.RUnlock()
 
-	if e.MaxMatches > 0 && e.matches >= e.MaxMatches {
+	if e.MaxMatches > 0 && e.Matches >= e.MaxMatches {
 		return false, nil
 	}
 

--- a/proxy.go
+++ b/proxy.go
@@ -25,7 +25,7 @@ func (s *Server) handleProxyRequest(r *http.Request, ctx *goproxy.ProxyCtx) (*ht
 		return r, goproxy.NewResponse(r, goproxy.ContentTypeText, http.StatusNotFound, fmt.Sprintf("everdeen: no expectation matched request"))
 	} else {
 		expectation.mutex.Lock()
-		expectation.matches += 1
+		expectation.Matches += 1
 		expectation.mutex.Unlock()
 
 		if expectation.PassThrough {


### PR DESCRIPTION
This PR adds 2 new endpoints to the API:
- `GET /ping` for checking the proxy is up and ready to receive requests.
- `GET /expectations` for checking which expectations have been created, and how many times they have matched.

Have at it! 🎁 
