### PR TITLE
Make it possible to override the CA certificate used for MITM

### DIFF
--- a/certs/certs.go
+++ b/certs/certs.go
@@ -1,0 +1,175 @@
+// TODO: provide attribution to original authors (https://github.com/SpectoLabs/hoverfly/blob/718c09aaabc3c2b36ab48abb78bc3a43404108c7/certs/certs.go)
+package certs
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"time"
+
+	"os"
+)
+
+// MaxSerialNumber - nothing very original, big number
+var MaxSerialNumber = big.NewInt(0).SetBytes(bytes.Repeat([]byte{255}, 20))
+
+// GenerateAndSave - generates cert and key and saves them on your disk
+func GenerateAndSave(name, organization string, validity time.Duration) (tlsc *tls.Certificate, err error) {
+	x509c, priv, err := NewCertificatePair(name, organization, validity)
+	if err != nil {
+		return
+	}
+
+	certOut, err := os.Create("cert.pem")
+	if err != nil {
+		return
+	}
+	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: x509c.Raw})
+	certOut.Close()
+
+	keyOut, err := os.OpenFile("key.pem", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return
+	}
+	pemBlock, err := PemBlockForKey(priv)
+	if err != nil {
+		return
+	}
+	pem.Encode(keyOut, pemBlock)
+	keyOut.Close()
+
+	tlsc, err = GetTLSCertificate(x509c, priv, "everdeen.proxy", validity)
+	return
+}
+
+// PemBlockForKey - based on key returns a block
+func PemBlockForKey(priv interface{}) (*pem.Block, error) {
+	switch k := priv.(type) {
+	case *rsa.PrivateKey:
+		return &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}, nil
+	case *ecdsa.PrivateKey:
+		b, err := x509.MarshalECPrivateKey(k)
+		return &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}, err
+	default:
+		return nil, nil
+	}
+}
+
+// NewCertificatePair - returns x509 cert + private key
+func NewCertificatePair(name, organization string, validity time.Duration) (*x509.Certificate, *rsa.PrivateKey, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+	pub := priv.Public()
+
+	pkixpub, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, nil, err
+	}
+	h := sha1.New()
+	h.Write(pkixpub)
+	keyID := h.Sum(nil)
+
+	serial, err := rand.Int(rand.Reader, MaxSerialNumber)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   name,
+			Organization: []string{organization},
+		},
+		SubjectKeyId:          keyID,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		NotBefore:             time.Now().Add(-validity),
+		NotAfter:              time.Now().Add(validity),
+		DNSNames:              []string{name},
+		IsCA:                  true,
+	}
+
+	raw, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, pub, priv)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	x509c, err := x509.ParseCertificate(raw)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return x509c, priv, nil
+}
+
+// GetTLSCertificate - takes x509 cert and private key, returns tls.Certificate that is ready for proxy use
+func GetTLSCertificate(cert *x509.Certificate, priv *rsa.PrivateKey, hostname string, validity time.Duration) (*tls.Certificate, error) {
+	host, _, err := net.SplitHostPort(hostname)
+	if err == nil {
+		hostname = host
+	}
+	pub := priv.Public()
+
+	pkixpub, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, err
+	}
+	h := sha1.New()
+	h.Write(pkixpub)
+	keyID := h.Sum(nil)
+
+	serial, err := rand.Int(rand.Reader, MaxSerialNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   hostname,
+			Organization: cert.Subject.Organization,
+		},
+		SubjectKeyId:          keyID,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		NotBefore:             time.Now().Add(validity),
+		NotAfter:              time.Now().Add(validity),
+	}
+
+	if ip := net.ParseIP(hostname); ip != nil {
+		tmpl.IPAddresses = []net.IP{ip}
+	} else {
+		tmpl.DNSNames = []string{hostname}
+	}
+
+	raw, err := x509.CreateCertificate(rand.Reader, tmpl, cert, priv.Public(), priv)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse certificate bytes to get a leaf certificate
+	x509c, err := x509.ParseCertificate(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsc := &tls.Certificate{
+		Certificate: [][]byte{raw, cert.Raw},
+		PrivateKey:  priv,
+		Leaf:        x509c,
+	}
+
+	return tlsc, nil
+}

--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -1,0 +1,109 @@
+package certs
+
+import (
+	"crypto/x509"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestNewCert(t *testing.T) {
+	x509c, _, err := NewCertificatePair("certy.com", "cert authority", 365*24*time.Hour)
+	if err != nil {
+		t.Errorf("Failed to generate certificate and key pair, got error: %s", err.Error())
+	}
+
+	if err := x509c.VerifyHostname("certy.com"); err != nil {
+		t.Errorf("x509c.VerifyHostname(%q): got %v, want no error", "certy.com", err)
+	}
+
+	if got, want := x509c.Subject.Organization, []string{"cert authority"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("x509c.Subject.Organization: got %v, want %v", got, want)
+	}
+
+	if got := x509c.SubjectKeyId; got == nil {
+		t.Error("x509c.SubjectKeyId: got nothing, want key ID")
+	}
+	if !x509c.BasicConstraintsValid {
+		t.Error("x509c.BasicConstraintsValid: got false, want true")
+	}
+
+	if got, want := x509c.KeyUsage, x509.KeyUsageKeyEncipherment; got&want == 0 {
+		t.Error("x509c.KeyUsage: got nothing, want to include x509.KeyUsageKeyEncipherment")
+	}
+	if got, want := x509c.KeyUsage, x509.KeyUsageDigitalSignature; got&want == 0 {
+		t.Error("x509c.KeyUsage: got nothing, want to include x509.KeyUsageDigitalSignature")
+	}
+
+	want := []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	if got := x509c.ExtKeyUsage; !reflect.DeepEqual(got, want) {
+		t.Errorf("x509c.ExtKeyUsage: got %v, want %v", got, want)
+	}
+
+	if got, want := x509c.DNSNames, []string{"certy.com"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("x509c.DNSNames: got %v, want %v", got, want)
+	}
+}
+
+func TestNewPriv(t *testing.T) {
+	_, priv, err := NewCertificatePair("certy.com", "cert authority", 365*24*time.Hour)
+	if err != nil {
+		t.Errorf("Failed to generate certificate and key pair, got error: %s", err.Error())
+	}
+
+	err = priv.Validate()
+	if err != nil {
+		t.Errorf("Key validation failed, got error: %s", err.Error())
+	}
+}
+
+func TestTlsCert(t *testing.T) {
+	pub, priv, err := NewCertificatePair("certy.com", "cert authority", 365*24*time.Hour)
+	if err != nil {
+		t.Errorf("Failed to generate certificate and key pair, got error: %s", err.Error())
+	}
+	tlsc, err := GetTLSCertificate(pub, priv, "hoverfly.proxy", 365*24*time.Hour)
+	if err != nil {
+		t.Errorf("Failed to get tls cert, got error: %s", err.Error())
+	}
+
+	x509c := tlsc.Leaf
+	if x509c == nil {
+		t.Fatal("x509c: got nil, want *x509.Certificate")
+	}
+	if got := x509c.SerialNumber; got.Cmp(MaxSerialNumber) >= 0 {
+		t.Errorf("x509c.SerialNumber: got %v, want <= MaxSerialNumber", got)
+	}
+	if got, want := x509c.Subject.CommonName, "hoverfly.proxy"; got != want {
+		t.Errorf("X509c.Subject.CommonName: got %q, want %q", got, want)
+	}
+	if err := x509c.VerifyHostname("hoverfly.proxy"); err != nil {
+		t.Errorf("x509c.VerifyHostname(%q): got %v, want no error", "certy.com", err)
+	}
+
+}
+
+func TestGenerateAndSave(t *testing.T) {
+	tlsc, err := GenerateAndSave("certy", "cert authority", "cert.pem", "key.pem", 1*24*time.Hour)
+	if err != nil {
+		t.Errorf("Failed to generate tls certificate, got error: %s", err.Error())
+	}
+	x509c := tlsc.Leaf
+	if x509c == nil {
+		t.Errorf("x509c: got nil, want *x509.Certificate")
+	}
+
+	if _, err := os.Stat("cert.pem"); os.IsNotExist(err) {
+		t.Errorf("expected to find it but cert.pem was not created!")
+	} else {
+		os.Remove("cert.pem")
+	}
+
+	if _, err := os.Stat("key.pem"); os.IsNotExist(err) {
+		t.Errorf("expected to find it but key.pem was not created!")
+	} else {
+		os.Remove("key.pem")
+	}
+
+}

--- a/main.go
+++ b/main.go
@@ -1,17 +1,44 @@
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"log"
 	"net/http"
+	"time"
+
+	"github.com/geckoboard/everdeen/certs"
 
 	"gopkg.in/elazarl/goproxy.v1"
 )
 
+var (
+	proxyAddr   = flag.String("proxy-addr", ":4321", "Listen address for the HTTP proxy")
+	controlAddr = flag.String("control-addr", ":4322", "Listen address for the control API")
+	caCertPath  = flag.String("ca-cert-path", "", "Path to CA certificate file")
+	caKeyPath   = flag.String("ca-key-path", "", "Path to CA private key file")
+
+	generateCA = flag.Bool("generate-ca-cert", false, "Generate CA certificate and private key for MITM")
+)
+
 func main() {
-	proxyAddr := flag.String("proxy-addr", ":4321", "Listen address for the HTTP proxy")
-	controlAddr := flag.String("control-addr", ":4322", "Listen address for the control API")
 	flag.Parse()
+
+	if *generateCA {
+		generateCACert()
+	} else {
+		startProxy()
+	}
+}
+
+func startProxy() {
+	if *caCertPath != "" && *caKeyPath != "" {
+		tlsc, err := tls.LoadX509KeyPair(*caCertPath, *caKeyPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		goproxy.GoproxyCa = tlsc
+	}
 
 	proxy := goproxy.NewProxyHttpServer()
 
@@ -23,4 +50,11 @@ func main() {
 	proxy.OnRequest().HandleConnect(goproxy.AlwaysMitm)
 	proxy.OnRequest().DoFunc(server.handleProxyRequest)
 	log.Fatal(http.ListenAndServe(*proxyAddr, proxy))
+}
+
+func generateCACert() {
+	_, err := certs.GenerateAndSave("everdeen.proxy", "Everdeen Authority", 365*24*time.Hour)
+	if err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
Trusting the default goproxy CA certificate on our development machines is a really bad idea, so we should be able to use a custom one.

```
everdeen -generate-ca-cert
everdeen -ca-cert-path=cert.pem -ca-key-path=key.pem
```

This uses the CA certificate generation code [from the excellent hoverfly project](https://github.com/SpectoLabs/hoverfly/blob/718c09aaabc3c2b36ab48abb78bc3a43404108c7/certs/certs.go).

Before we open source everdeen we need to make sure we honour their licence (Apache 2.0)
