### PR TITLE
Add support for matching on query strings

### DIFF
--- a/everdeen_test.go
+++ b/everdeen_test.go
@@ -412,6 +412,131 @@ func TestMethodExpectation(t *testing.T) {
 			},
 		},
 
+		// Query Param Matcher (Single / Exact)
+		{
+			expectations: []Expectation{
+				{
+					RequestCriteria: Criteria{
+						{
+							Type:  CriteriaTypeQueryParam,
+							Key:   "q",
+							Value: "Search Term",
+						},
+					},
+
+					RespondWith: RespondWith{
+						Status: 418,
+						Body:   "Proxy Response",
+					},
+				},
+			},
+			scenarios: []scenario{
+				{
+					request{
+						method: "GET",
+						url:    websiteServer.URL + "?q=Search+Term",
+					},
+					response{
+						status: 418,
+						body:   "Proxy Response",
+					},
+				},
+				{
+					request{
+						method: "GET",
+						url:    websiteServer.URL + "?q=Something+Else",
+					},
+					blockedResponse,
+				},
+			},
+		},
+
+		// Query Param Matcher (Many / Exact)
+		{
+			expectations: []Expectation{
+				{
+					RequestCriteria: Criteria{
+						{
+							Type:   CriteriaTypeQueryParam,
+							Key:    "name",
+							Values: []string{"Jack", "Sally"},
+						},
+					},
+
+					RespondWith: RespondWith{
+						Status: 418,
+						Body:   "Proxy Response",
+					},
+				},
+			},
+			scenarios: []scenario{
+				{
+					request{
+						method: "GET",
+						url:    websiteServer.URL + "?name=Sally&name=Jack",
+					},
+					response{
+						status: 418,
+						body:   "Proxy Response",
+					},
+				},
+				{
+					request{
+						method: "GET",
+						url:    websiteServer.URL + "?name=Jack",
+					},
+					blockedResponse,
+				},
+				{
+					request{
+						method: "GET",
+						url:    websiteServer.URL + "?name=Sally",
+					},
+					blockedResponse,
+				},
+			},
+		},
+
+		// Query Param Matcher (Regex)
+		{
+			expectations: []Expectation{
+				{
+					RequestCriteria: Criteria{
+						{
+							Type:      CriteriaTypeQueryParam,
+							Key:       "name",
+							MatchType: MatchTypeRegex,
+							Value:     "Dan(iel)?",
+						},
+					},
+
+					RespondWith: RespondWith{
+						Status: 418,
+						Body:   "Proxy Response",
+					},
+				},
+			},
+			scenarios: []scenario{
+				{
+					request{
+						method: "GET",
+						url:    websiteServer.URL + "?name=Daniel",
+					},
+					response{
+						status: 418,
+						body:   "Proxy Response",
+					},
+				},
+				{
+					request{
+						method: "GET",
+						url:    websiteServer.URL + "?q=Fred",
+					},
+					blockedResponse,
+				},
+			},
+		},
+
 		// Responding With Custom Headers
 		{
 			expectations: []Expectation{


### PR DESCRIPTION
This PR adds support for 3 kinds of query string parameter matching:
#### Exact (Single Value)

This will match all requests where the given query string parameter is _exactly_ the given value:

``` json
{
  "request_criteria": [
    {
      "type": "query_param",
      "key": "q",
      "value": "Search Query"
    }
  ]
}
```

Like so:

```
GET /search?q=Search+Query
```
#### Exact (Multiple Values)

This will match all requests where the given query string parameter has multiple values _exactly_ matching the given array of values.

``` json
{
  "request_criteria": [
    {
      "type": "query_param",
      "key": "name",
      "values": ["Jack", "Sally"]
    }
  ]
}
```

Like so:

```
GET /live_like?name=Jack&name=Sally
```

This will not match:

```
GET /live_like?name=Jack&name=Sally&name=Christopher
```
#### Regex (Single Value)

``` json
{
  "request_criteria": [
    {
      "type": "query_param",
      "key": "name",
      "match_type": "regex",
      "value": "(Jack|Sally)"
    }
  ]
}
```

Like so:

```
GET /live_like?name=Jack
```
