### PR TITLE
Add MIT Licence, and Apache 2 Licence to files taken from Hoverfly

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2016 Geckoboard
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/certs/certs.go
+++ b/certs/certs.go
@@ -1,4 +1,19 @@
-// TODO: provide attribution to original authors (https://github.com/SpectoLabs/hoverfly/blob/718c09aaabc3c2b36ab48abb78bc3a43404108c7/certs/certs.go)
+/*
+	This file is a modified version of:
+		https://github.com/SpectoLabs/hoverfly/blob/718c09aaabc3c2b36ab48abb78bc3a43404108c7/certs/certs.go
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
 package certs
 
 import (

--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -1,3 +1,19 @@
+/*
+	This file is a modified version of:
+		https://github.com/SpectoLabs/hoverfly/blob/718c09aaabc3c2b36ab48abb78bc3a43404108c7/certs/certs_test.go
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
 package certs
 
 import (


### PR DESCRIPTION
I _think_ this should be enough attribution, but @leocassarani also recommended we open an issue on the Hoverfly project once Everdeen is open source to check it's ok 😄 
