### PR TITLE
Log all request/responses and when no expectation matches log

### DIFF
--- a/api.go
+++ b/api.go
@@ -137,6 +137,8 @@ func (s *Server) createExpectations(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("everdeen: %s", err), http.StatusInternalServerError)
 		log.Printf("ERROR: %v", err)
 	}
+
+	logExpectationRequest(expectations)
 }
 
 func prepareExpectations(request CreateExpectationsRequest) ([]*Expectation, error) {

--- a/logging.go
+++ b/logging.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+type requestLog struct {
+	URL     string
+	Method  string
+	Headers map[string][]string
+	Body    string
+}
+
+type responseLog struct {
+	Status  int
+	Headers map[string][]string
+	Body    string
+}
+
+func logProxyRequest(r *http.Request) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("Failed to read body from request: %s", err)
+		return
+	}
+
+	r.Body.Close()
+	r.Body = ioutil.NopCloser(bytes.NewReader(b))
+
+	rl := &requestLog{
+		URL:     r.URL.String(),
+		Method:  r.Method,
+		Headers: r.Header,
+		Body:    string(b),
+	}
+
+	rb, err := json.MarshalIndent(rl, "", "  ")
+	if err != nil {
+		log.Printf("Error marshal request for logging %s", err)
+		return
+	}
+
+	log.Printf("Request through proxy:\n%s\n", string(rb))
+}
+
+func logProxyRequestResponse(r *http.Response) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("Failed to read body from response: %s", err)
+		return
+	}
+
+	r.Body.Close()
+	r.Body = ioutil.NopCloser(bytes.NewReader(b))
+
+	rl := &responseLog{
+		Status:  r.StatusCode,
+		Headers: r.Header,
+		Body:    string(b),
+	}
+
+	rb, err := json.MarshalIndent(rl, "", "  ")
+	if err != nil {
+		log.Printf("Error marshaling response for logging %s", err)
+		return
+	}
+
+	log.Printf("Proxy response for %s\n%s\n", r.Request.URL, string(rb))
+}
+
+func logExpectationRequest(exp []*Expectation) {
+	b, err := json.MarshalIndent(exp, "", "  ")
+	if err != nil {
+		log.Printf("Error marshalling expectation request for logging %s", err)
+		return
+	}
+
+	log.Printf("Register expectations request:\n%s\n", string(b))
+}

--- a/main.go
+++ b/main.go
@@ -92,9 +92,15 @@ func startProxy() {
 	http.Handle("/", server)
 	go http.ListenAndServe(*controlAddr, nil)
 
-	proxy.Verbose = true
 	proxy.OnRequest().HandleConnect(goproxy.AlwaysMitm)
 	proxy.OnRequest().DoFunc(server.handleProxyRequest)
+
+	// Used for logging out responses that pass through to the third party to
+	// allow easy setup of new mock responses
+	proxy.OnResponse().DoFunc(func(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
+		logProxyRequestResponse(resp)
+		return resp
+	})
 	log.Fatal(http.ListenAndServe(*proxyAddr, proxy))
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -17,6 +17,8 @@ func (s *Server) handleProxyRequest(r *http.Request, ctx *goproxy.ProxyCtx) (*ht
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
+	logProxyRequest(r)
+
 	expectation, err := s.findMatchingExpectation(r)
 	if err != nil {
 		return r, goproxy.NewResponse(r, goproxy.ContentTypeText, http.StatusBadGateway, fmt.Sprintf("everdeen: %s", err))


### PR DESCRIPTION
that nothing matched that request.
#### So now we log expectation requests

```
2016/07/27 14:53:29 Register expectations request:
[
  {
    "request_criteria": [
      {
        "type": "method",
        "key": "",
        "match_type": "exact",
        "value": "POST",
        "values": null
      }
    ],
    "respond_with": {
      "status": 0,
      "headers": null,
      "body": "",
      "body_encoding": ""
    },
    "max_matches": 0,
    "pass_through": true,
    "store_matching_requests": false,
    "uuid": "b1f4be5b-7f30-442e-a4af-9190cabac2fc",
    "matches": 0
  }
]

```
#### Logs requests and the response out to the third party and/or the expectation mock response

No matching expectation

```
2016/07/27 15:15:51 Request through proxy:
{
  "URL": "https://google.com:443/",
  "Method": "GET",
  "Headers": {
    "Accept": [
      "*/*"
    ],
    "User-Agent": [
      "curl/7.43.0"
    ]
  },
  "Body": ""
}
2016/07/27 15:15:51 Proxy response for https://google.com:443/
{
  "Status": 404,
  "Headers": {
    "Content-Type": [
      "text/plain"
    ]
  },
  "Body": "everdeen: no expectation matched request"
}
```

Expectation response

```
2016/07/27 15:11:21 Request through proxy:
{
  "URL": "https://google.com:443/",
  "Method": "GET",
  "Headers": {
    "Accept": [
      "*/*"
    ],
    "User-Agent": [
      "curl/7.43.0"
    ]
  },
  "Body": ""
}
2016/07/27 15:11:21 Proxy response for https://google.com:443/
{
  "Status": 422,
  "Headers": {},
  "Body": "You made this mock response"
}
```

Third party response

```
2016/07/27 15:12:12 Request through proxy:
{
  "URL": "https://example.com:443/",
  "Method": "POST",
  "Headers": {
    "Accept": [
      "*/*"
    ],
    "Content-Length": [
      "18"
    ],
    "Content-Type": [
      "application/x-www-form-urlencoded"
    ],
    "User-Agent": [
      "curl/7.43.0"
    ]
  },
  "Body": "{\"bklash\": \"fdfd\"}"
}
2016/07/27 15:12:13 Proxy response for https://example.com:443/
{
  "Status": 200,
  "Headers": {
    "Accept-Ranges": [
      "bytes"
    ],
    "Cache-Control": [
      "max-age=604800"
    ],
    "Content-Length": [
      "1270"
    ],
    "Content-Type": [
      "text/html"
    ],
    "Date": [
      "Wed, 27 Jul 2016 14:11:57 GMT"
    ],
    "Etag": [
      "\"359670651\""
    ],
    "Expires": [
      "Wed, 03 Aug 2016 14:11:57 GMT"
    ],
    "Last-Modified": [
      "Fri, 09 Aug 2013 23:54:35 GMT"
    ],
    "Server": [
      "EOS (lax004/2821)"
    ]
  },
  "Body": "\u003c!doctype html\u003e\n\u003chtml\u003e\n\u003chead\u003e\n    \u003ctitle\u003eExample Domain\u003c/title\u003e\n\n    \u003cmeta charset=\"utf-8\" /\u003e\n    \u003cmeta http-equiv=\"Content-type\" content=\"text/html; charset=utf-8\" /\u003e\n    \u003cmeta name=\"viewport\" content=\"width=device-width, initial-scale=1\" /\u003e\n    \u003cstyle type=\"text/css\"\u003e\n    body {\n        background-color: #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: \"Open Sans\", \"Helvetica Neue\", Helvetica, Arial, sans-serif;\n        \n    }\n    div {\n        width: 600px;\n        margin: 5em auto;\n        padding: 50px;\n        background-color: #fff;\n        border-radius: 1em;\n    }\n    a:link, a:visited {\n        color: #38488f;\n        text-decoration: none;\n    }\n    @media (max-width: 700px) {\n        body {\n            background-color: #fff;\n        }\n        div {\n            width: auto;\n            margin: 0 auto;\n            border-radius: 0;\n            padding: 1em;\n        }\n    }\n    \u003c/style\u003e    \n\u003c/head\u003e\n\n\u003cbody\u003e\n\u003cdiv\u003e\n    \u003ch1\u003eExample Domain\u003c/h1\u003e\n    \u003cp\u003eThis domain is established to be used for illustrative examples in documents. You may use this\n    domain in examples without prior coordination or asking for permission.\u003c/p\u003e\n    \u003cp\u003e\u003ca href=\"http://www.iana.org/domains/example\"\u003eMore information...\u003c/a\u003e\u003c/p\u003e\n\u003c/div\u003e\n\u003c/body\u003e\n\u003c/html\u003e\n"
}
```
