### PR TITLE
Implement a reset all endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,22 @@ requests.first.body
 => "Hello World"
 ```
 
+#### Resetting all expectations
+
+In cases where you need to reset all registered expectations and stored request stores to its
+initial clean state, you can use the reset\_all endpoint making a `DELETE` request to the
+control-addr endpoint.
+
+```
+curl localhost:4322/reset_all -XDELETE
+OK
+```
+
+```ruby
+server = Everdeen::Server.new(...)
+server.reset_all
+```
+
 #### Proxying HTTPS Traffic
 
 Due to the secure nature of TLS; HTTPS requests can't be proxied transparently. To overcome this problem, the Everdeen proxy will act as a [Certificate Authority](https://en.wikipedia.org/wiki/Certificate_authority) and decrypt / re-encrypt traffic using it's own self-signed certificates.

--- a/README.md
+++ b/README.md
@@ -215,11 +215,11 @@ requests.first.body
 #### Resetting all expectations
 
 In cases where you need to reset all registered expectations and stored request stores to its
-initial clean state, you can use the reset\_all endpoint making a `DELETE` request to the
+initial clean state, you can use the `/reset/all` endpoint making a `DELETE` request to the
 control-addr endpoint.
 
 ```
-curl localhost:4322/reset_all -XDELETE
+curl localhost:4322/reset/all -XDELETE
 OK
 ```
 

--- a/api.go
+++ b/api.go
@@ -59,7 +59,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		s.findRequests(w, r)
-	case "/reset_all":
+	case "/reset/all":
 		if r.Method != "DELETE" {
 			http.Error(w, "everdeen: Method Not Allowed", http.StatusMethodNotAllowed)
 			return

--- a/everdeen_test.go
+++ b/everdeen_test.go
@@ -967,3 +967,65 @@ func createExpectations(t *testing.T, server *Server, cer *CreateExpectationsReq
 
 	return expectations
 }
+
+func TestResetAllEndpointRequest(t *testing.T) {
+	proxy, proxyServer, _ := buildProxy()
+	defer proxyServer.Close()
+
+	server := &Server{Proxy: proxy}
+	proxy.OnRequest().DoFunc(server.handleProxyRequest)
+
+	expectations := []Expectation{
+		{
+			RequestCriteria: Criteria{
+				{
+					Type:  CriteriaTypeHost,
+					Value: "www.google.com",
+				},
+			},
+		},
+	}
+
+	cer := CreateExpectationsRequest{expectations}
+	createExpectations(t, server, &cer)
+
+	// Check that one expectation exists
+	exps := listsExpectationsResponse(t, server)
+	if len(exps) != 1 {
+		t.Errorf("Expected one expectation to be returned but got %d", len(exps))
+	}
+
+	// Now post to the reset_all endpoint
+	req, err := http.NewRequest("DELETE", "/reset_all", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Errorf("Expected 200 response code to /reset_all but got %d", rec.Code)
+	}
+
+	// Now query the expectations endpoint and verify none exist
+	exps = listsExpectationsResponse(t, server)
+	if len(exps) != 0 {
+		t.Errorf("Expected no expectations to be returned but got %d", len(exps))
+	}
+}
+
+func listsExpectationsResponse(t *testing.T, server *Server) []*Expectation {
+	req, err := http.NewRequest("GET", "/expectations", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, req)
+
+	var exps []*Expectation
+	json.Unmarshal(rec.Body.Bytes(), &exps)
+
+	return exps
+}

--- a/everdeen_test.go
+++ b/everdeen_test.go
@@ -996,7 +996,7 @@ func TestResetAllEndpointRequest(t *testing.T) {
 	}
 
 	// Now post to the reset_all endpoint
-	req, err := http.NewRequest("DELETE", "/reset_all", nil)
+	req, err := http.NewRequest("DELETE", "/reset/all", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ruby_client/lib/everdeen/client.rb
+++ b/ruby_client/lib/everdeen/client.rb
@@ -33,6 +33,13 @@ module Everdeen
       end
     end
 
+    def reset_all
+      uri = build_uri('/reset_all')
+      req = Net::HTTP::Delete.new(uri.path)
+
+      Net::HTTP.start(uri.host, uri.port) { |http| http.request(req) }
+    end
+
     private
 
     def build_uri(path)

--- a/ruby_client/lib/everdeen/client.rb
+++ b/ruby_client/lib/everdeen/client.rb
@@ -34,7 +34,7 @@ module Everdeen
     end
 
     def reset_all
-      uri = build_uri('/reset_all')
+      uri = build_uri('/reset/all')
       req = Net::HTTP::Delete.new(uri.path)
 
       Net::HTTP.start(uri.host, uri.port) { |http| http.request(req) }

--- a/ruby_client/lib/everdeen/server.rb
+++ b/ruby_client/lib/everdeen/server.rb
@@ -38,6 +38,10 @@ module Everdeen
       client.requests(expectation_id)['requests'].collect { |req| Request.new(req) }
     end
 
+    def reset_all
+      client.reset_all
+    end
+
     def stop
       Process.kill(:INT, @pipe.pid)
     end

--- a/ruby_client/spec/everdeen_spec.rb
+++ b/ruby_client/spec/everdeen_spec.rb
@@ -28,22 +28,7 @@ RSpec.describe Everdeen, type: :integration do
   end
 
   example 'requesting matching processed requests' do
-    expectations = server.create_expectations([
-      Everdeen::Expectation.new(
-        store_matching_requests: true,
-        request_criteria: [
-          {
-            type: 'method',
-            value: "POST"
-          }
-        ],
-
-        response: {
-          status: 200,
-          body: 'Hello World'
-        }
-      )
-    ])
+    expectations = create_expectations
 
     Net::HTTP.new('127.0.0.1', 4321, nil, nil).start do |http|
       request = Net::HTTP::Post.new 'https://example.com/test'
@@ -69,11 +54,42 @@ RSpec.describe Everdeen, type: :integration do
     expect(request.body_base64).to eq "SGVsbG8gV29ybGQ="
   end
 
+  example 'resetting all expectations' do
+    create_expectations
+
+    requests = server.registered_expectations
+    expect(requests.size).to eq 1
+
+    server.reset_all
+
+    requests = server.registered_expectations
+    expect(requests.size).to eq 0
+  end
+
   def start_server
     Everdeen::Server.start(
       proxy_port: 4321,
       control_port: 4322,
       store_requests: true
     )
+  end
+
+  def create_expectations
+    server.create_expectations([
+      Everdeen::Expectation.new(
+        store_matching_requests: true,
+        request_criteria: [
+          {
+            type: 'method',
+            value: "POST"
+          }
+        ],
+
+        response: {
+          status: 200,
+          body: 'Hello World'
+        }
+      )
+    ])
   end
 end


### PR DESCRIPTION
And ensure to return so that when a http method is invalid return immediately.

This PR is required for for speed up of the acceptance test framework to leave the apps in proxy mode permanently on the local dev vm