### PR TITLE
Ensure that everdeen binary name for packaging is the same on each build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ install-ci-deps:
 
 package: build
 	@mkdir -p pkg tmp/bin
-	@cp $(BUILD_DIR)/$(NAME)_$(SERVER_VERSION)_linux-amd64 tmp/bin
+	@cp $(BUILD_DIR)/$(NAME)_$(SERVER_VERSION)_linux-amd64 tmp/bin/everdeen
 	fpm -C tmp -t deb -s dir --name $(NAME) --version $(DEB_VERSION) --prefix /usr/local/ --provides $(NAME) --force .
 	@mv $(NAME)_$(DEB_VERSION)_amd64.deb pkg
 


### PR DESCRIPTION
Previously it was whatever the everdeen SERVER_VERSION was and therefore causing some issues  when we made a deb package for installation on the vm