### PR TITLE
Log proxy requests for being able to setup mocks easier

### DIFF
--- a/api.go
+++ b/api.go
@@ -137,6 +137,8 @@ func (s *Server) createExpectations(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("everdeen: %s", err), http.StatusInternalServerError)
 		log.Printf("ERROR: %v", err)
 	}
+
+	logExpectationRequest(expectations)
 }
 
 func prepareExpectations(request CreateExpectationsRequest) ([]*Expectation, error) {

--- a/logging.go
+++ b/logging.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+type requestLog struct {
+	URL     string
+	Method  string
+	Headers map[string][]string
+	Body    string
+}
+
+type responseLog struct {
+	Status  int
+	Headers map[string][]string
+	Body    string
+}
+
+func logProxyRequest(r *http.Request) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("Failed to read body from request: %s", err)
+		return
+	}
+
+	r.Body.Close()
+	r.Body = ioutil.NopCloser(bytes.NewReader(b))
+
+	rl := &requestLog{
+		URL:     r.URL.String(),
+		Method:  r.Method,
+		Headers: r.Header,
+		Body:    string(b),
+	}
+
+	rb, err := json.MarshalIndent(rl, "", "  ")
+	if err != nil {
+		log.Printf("Error marshal request for logging %s", err)
+		return
+	}
+
+	log.Printf("Request through proxy:\n%s\n", string(rb))
+}
+
+func logProxyRequestResponse(r *http.Response) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("Failed to read body from response: %s", err)
+		return
+	}
+
+	r.Body.Close()
+	r.Body = ioutil.NopCloser(bytes.NewReader(b))
+
+	rl := &responseLog{
+		Status:  r.StatusCode,
+		Headers: r.Header,
+		Body:    string(b),
+	}
+
+	rb, err := json.MarshalIndent(rl, "", "  ")
+	if err != nil {
+		log.Printf("Error marshaling response for logging %s", err)
+		return
+	}
+
+	log.Printf("Proxy response for %s\n%s\n", r.Request.URL, string(rb))
+}
+
+func logExpectationRequest(exp []*Expectation) {
+	b, err := json.MarshalIndent(exp, "", "  ")
+	if err != nil {
+		log.Printf("Error marshalling expectation request for logging %s", err)
+		return
+	}
+
+	log.Printf("Register expectations request:\n%s\n", string(b))
+}

--- a/main.go
+++ b/main.go
@@ -11,9 +11,9 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/elazarl/goproxy"
 	"github.com/geckoboard/everdeen/certs"
 	"github.com/satori/go.uuid"
-	"github.com/elazarl/goproxy"
 )
 
 // Injected by the Makefile
@@ -75,16 +75,16 @@ func startProxy() {
 
 	if *passthroughMode {
 		exp := Expectation{
-				Uuid: uuid.NewV4(),
-				PassThrough: true,
-				RequestCriteria: Criteria{
-					{
-						Type:  CriteriaTypeHost,
-						regexp: regexp.MustCompile(".*"),
-						MatchType: MatchTypeRegex,
-					},
+			Uuid:        uuid.NewV4(),
+			PassThrough: true,
+			RequestCriteria: Criteria{
+				{
+					Type:      CriteriaTypeHost,
+					regexp:    regexp.MustCompile(".*"),
+					MatchType: MatchTypeRegex,
 				},
-			}
+			},
+		}
 
 		server.expectations = append(server.expectations, &exp)
 	}
@@ -95,10 +95,10 @@ func startProxy() {
 	proxy.OnRequest().HandleConnect(goproxy.AlwaysMitm)
 	proxy.OnRequest().DoFunc(server.handleProxyRequest)
 
-	// Used for logging out responses that pass through to the third party to
+	// Used for logging out responses that pass through the proxy to
 	// allow easy setup of new mock responses
 	proxy.OnResponse().DoFunc(func(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
-		logProxyRequestResponse(resp)
+		logProxyRequestResponse(ctx.Req, resp)
 		return resp
 	})
 	log.Fatal(http.ListenAndServe(*proxyAddr, proxy))

--- a/main.go
+++ b/main.go
@@ -92,9 +92,15 @@ func startProxy() {
 	http.Handle("/", server)
 	go http.ListenAndServe(*controlAddr, nil)
 
-	proxy.Verbose = true
 	proxy.OnRequest().HandleConnect(goproxy.AlwaysMitm)
 	proxy.OnRequest().DoFunc(server.handleProxyRequest)
+
+	// Used for logging out responses that pass through to the third party to
+	// allow easy setup of new mock responses
+	proxy.OnResponse().DoFunc(func(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
+		logProxyRequestResponse(resp)
+		return resp
+	})
 	log.Fatal(http.ListenAndServe(*proxyAddr, proxy))
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -17,8 +17,6 @@ func (s *Server) handleProxyRequest(r *http.Request, ctx *goproxy.ProxyCtx) (*ht
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	logProxyRequest(r)
-
 	expectation, err := s.findMatchingExpectation(r)
 	if err != nil {
 		return r, goproxy.NewResponse(r, goproxy.ContentTypeText, http.StatusBadGateway, fmt.Sprintf("everdeen: %s", err))

--- a/proxy.go
+++ b/proxy.go
@@ -17,6 +17,8 @@ func (s *Server) handleProxyRequest(r *http.Request, ctx *goproxy.ProxyCtx) (*ht
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
+	logProxyRequest(r)
+
 	expectation, err := s.findMatchingExpectation(r)
 	if err != nil {
 		return r, goproxy.NewResponse(r, goproxy.ContentTypeText, http.StatusBadGateway, fmt.Sprintf("everdeen: %s", err))


### PR DESCRIPTION
In my first attempt to log out request/response [here](https://github.com/geckoboard/everdeen/pull/23) there was some cleanup but since using it for real there was several issues with it outputting the encoded urls/body and us requiring the raw unencoded url/body.

Having had another look I found httputils which has DumpRequest and DumpResponse methods which dumps it in its HTTP 1.1 wire representation. https://golang.org/pkg/net/http/httputil/

So instead opted for stdlib and now it outputs nicely.

Logging the expectations is unaltered.

```
 Proxy response for request: https://example.com/projects/0.json?auth_token=tok123
 **** Request ****
 GET /projects/0.json?auth_token=tok123 HTTP/1.1
 Host: example.com
 Connection: close


 **** Response ****
 HTTP/1.1 200 OK
 Connection: close
 Content-Length: 429
 Content-Type: application/json
 Date: Wed, 24 Aug 2016 13:28:58 GMT

 {"project":{"id":0,"account_id":0,"name":"example","api_key":"api123", "notices_count":3136611 }
```
